### PR TITLE
feat: add level counter and overlay screen

### DIFF
--- a/app/src/main/java/ucs/aula12/trabalho_2/view/CanvasView.java
+++ b/app/src/main/java/ucs/aula12/trabalho_2/view/CanvasView.java
@@ -31,6 +31,7 @@ public class CanvasView extends View {
     public float ballY;
     public float wallWidth;
     public float wallHeight;
+    public int level;
 
     public int maze[][];
     private List<Coordinates> wallCoordinates = new ArrayList<Coordinates>();
@@ -39,6 +40,14 @@ public class CanvasView extends View {
     public CanvasView(Context c, AttributeSet attrs) {
         super(c, attrs);
         context = c;
+    }
+
+    public int getLevel() {
+        return level;
+    }
+
+    public void setLevel(int level) {
+        this.level = level;
     }
 
     public void setWallWidth(float displayWidth) {
@@ -115,6 +124,11 @@ public class CanvasView extends View {
         Bitmap b = BitmapFactory.decodeResource(getResources(), R.drawable.beyblade);
         Bitmap scaled = Bitmap.createScaledBitmap(b, (int) (wallWidth), (int) (wallWidth), false);
         canvas.drawBitmap(scaled, (ballX - (scaled.getWidth()/2)), (ballY - (scaled.getHeight()/2)), ball);
+
+        // Draw level
+        p2.setColor(Color.WHITE);
+        p2.setTextSize(90);
+        canvas.drawText("Nível: ".concat(Integer.toString(level)), 50, 130, p2);
     }
 
     public void clearCanvas() {

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -23,5 +23,25 @@
         custom:layout_constraintEnd_toEndOf="parent"
         />
 
+    <View
+        android:id="@+id/overlay_screen"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="#B5000000"
+        />
+
+    <TextView
+        android:id="@+id/overlay_text"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Aperte Start!"
+        custom:layout_constraintStart_toStartOf="parent"
+        custom:layout_constraintEnd_toEndOf="parent"
+        custom:layout_constraintTop_toTopOf="parent"
+        custom:layout_constraintBottom_toBottomOf="parent"
+        android:textColor="#fff"
+        android:textSize="50dp"
+        />
+
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
Adds a level counter at the top left of the maze, and an overlay screen when the game starts and ends.

**Adds level counter**
- Level increases as the player wins
- Level restarts when user restarts the game

**Overlay screen**
- When starting the application, the user sees a dark screen with a start message
- When the user reaches the final position of the maze, the nextLevel() function is called, disabling the accelerometer sensor and showing a dark screen with a victory message

**Logic** 
- startButton onClick event: Now checks if the button has been clicked to restart or to start a new level
- restartGame() method created and conditional on startGame() method removed